### PR TITLE
General handling fixes

### DIFF
--- a/source/defs.h
+++ b/source/defs.h
@@ -25,10 +25,12 @@
 
 #include "deftypes.h"
 
-#define BYTESMASHER			0xBA
+#define BYTESMASHER		0xBA
 #define MAX_CHANNELS		32
 extern int PANNING_SEP;
 
 //#define SUPER_ASCII
+
+#define CLAMP(x, a, b) ((x) < (a) ? (a) : ((x) > (b) ? (b) : (x)))
 
 #endif // _defs_h_

--- a/source/main.c
+++ b/source/main.c
@@ -266,7 +266,7 @@ int main(int argc, char* argv[])
 				}
 				strp = strlen(str_input);
 				str_output = (char*)malloc( strp+2 );
-				memcpy( str_output, str_input, strlen(str_input) );
+				strcpy(str_output, str_input);
 				strp=strlen(str_output)-1;
 				
 				for( strpi=strp; str_output[strpi] != '.' && strpi != 0; strpi-- );

--- a/source/mas.h
+++ b/source/mas.h
@@ -38,9 +38,9 @@
 #define SAMP_FORMAT_S16		(SAMPF_16BIT | SAMPF_SIGNED )
 #define SAMP_FORMAT_ADPCM	(SAMPF_COMP)
 
-#define MAS_MODE_GBA			0
-#define MAS_MODE_NDS			1
-#define MAS_MODE_NDS_DEP		2
+#define MAS_TYPE_SONG			0
+#define MAS_TYPE_SAMPLE_GBA		1
+#define MAS_TYPE_SAMPLE_NDS		2
 
 typedef struct tInstrument_Envelope
 {
@@ -156,6 +156,7 @@ typedef struct tMAS_Module
 
 void Write_Instrument_Envelope( Instrument_Envelope* env );
 void Write_Instrument( Instrument* inst );
+void Write_SampleData( Sample* samp );
 void Write_Sample( Sample* samp );
 void Write_Pattern( Pattern* patt, bool xm_vol );
 int Write_MAS( MAS_Module* mod, bool verbose, bool msl_dep );

--- a/source/s3m.c
+++ b/source/s3m.c
@@ -60,6 +60,8 @@ int Load_S3M_SampleData( Sample* samp, u8 ffi )
 {
 	u32 x;
 	int a;
+	if( samp->sample_length == 0 )
+		return ERR_NONE;
 	if( samp->format & SAMPF_16BIT )
 		samp->data = (u16*)malloc( samp->sample_length*2 );
 	else

--- a/source/samplefix.c
+++ b/source/samplefix.c
@@ -520,6 +520,10 @@ void FixSample_NDS( Sample* samp )
 
 void FixSample( Sample* samp )
 {
+	// Clamp loop_start and loop_end (f.e. FR_TOWER.MOD)
+	samp->loop_start = CLAMP(samp->loop_start, 0, samp->sample_length);
+	samp->loop_end = CLAMP(samp->loop_end, 0, samp->sample_length);
+
 	if( target_system == SYSTEM_GBA )
 		FixSample_GBA( samp );
 	else if( target_system == SYSTEM_NDS )

--- a/source/xm.c
+++ b/source/xm.c
@@ -250,6 +250,8 @@ int Load_XM_Instrument( Instrument* inst, MAS_Module* mas, u8* p_nextsample, boo
 		for( x = 0; x < nsamples; x++ )
 		{
 			samp = &mas->samples[ns+x];
+			if( samp->sample_length == 0 )
+				continue;
 			
 			sample_old = 0;
 			if( samp->format & SAMPF_16BIT )


### PR DESCRIPTION
- When loading .MOD files, only declare as many instruments and samples as the file
  itself, not the format maximum of 31 - this reduces the size of .MOD-derived songs and soundbanks by about 1KB/file on a good day.
- Fix processing of .MOD files with invalid loop start/end values
- Unify .MAS song and .MSL sample data generation code, fixing playback of
  samples embedded inside a .MAS song
- Unify MAS_VERSION at 0x18, as the generated data should now match between
  .MAS and .MSL generators.
- Replace memcpy() with strcpy() in main.c, fixing uninitialized memory usage
- Remove unused MAS_MODE constants, replace with more useful and format-accurate MAS_TYPE constants
- Avoid 0-byte malloc()s in sample data loading for .MOD, .S3M and .XM files