### PR TITLE
fix segfault on zero-length samples with looping enabled

### DIFF
--- a/source/mas.c
+++ b/source/mas.c
@@ -214,7 +214,7 @@ void Write_SampleData( Sample* samp )
 			write16( ((u16*)samp->data)[x] );
 
 		// add padding data
-		if( samp->loop_type )
+		if( samp->loop_type && sample_length >= (samp->loop_start + 2) )
 		{
 			write16( ((u16*)samp->data)[samp->loop_start] );
 			write16( ((u16*)samp->data)[samp->loop_start+1] );
@@ -231,7 +231,7 @@ void Write_SampleData( Sample* samp )
 			write8( ((u8*)samp->data)[x] );
 
 		// add padding data
-		if( samp->loop_type )
+		if( samp->loop_type && sample_length >= (samp->loop_start + 4) )
 		{
 			write8( ((u8*)samp->data)[samp->loop_start] );
 			write8( ((u8*)samp->data)[samp->loop_start+1] );


### PR DESCRIPTION
```
(gdb) run -b demo_core.xm -oTEST.gba
Starting program: mmutil -b demo_core.xm -oTEST.gba

Program received signal SIGSEGV, Segmentation fault.
0x0000555555558697 in Write_SampleData (samp=samp@entry=0x5555555768c0) at source/mas.c:236
236				write8( ((u8*)samp->data)[samp->loop_start] );
(gdb) print *samp
$2 = {parapointer = 0, global_volume = 64 '@', default_volume = 64 '@', default_panning = 192 '\300', sample_length = 0, 
  loop_start = 0, loop_end = 64, loop_type = 1 '\001', frequency = 8363, data = 0x0, vibtype = 0 '\000', vibdepth = 0 '\000', 
  vibspeed = 0 '\000', vibrate = 0 '\000', msl_index = 65535, rsamp_index = 0 '\000', format = 0 '\000', datapointer = 0, 
  it_compression = 0 '\000', name = ' ' <repeats 22 times>, "\000\000\000\000\000\000\000\000\000", 
  filename = ' ' <repeats 12 times>}
```

It appears that OpenMPT, after using "cleanup" to remove unused samples, will clear the sample length - but not the looping information. This will currently cause mmutil to crash, as it tries to read the first few samples of a zero-length sample. The PR should fix this.