### PR TITLE
samplefix.c: fix invalid memory read

### DIFF
--- a/source/samplefix.c
+++ b/source/samplefix.c
@@ -224,7 +224,7 @@ void Resample( Sample* samp, u32 newsize )
 									(samp->loop_type ? 
 										((double)(src16[lpoint + (posi + 1 - oldlength)])) : 0) : 
 										((double)(src16[posi+1]));
-			s3 = (posi+1) >= oldlength ? 
+			s3 = (posi+2) >= oldlength ?
 									(samp->loop_type ? 
 										((double)(src16[lpoint + (posi + 2 - oldlength)])) : 0) : 
 										((double)(src16[posi+2]));
@@ -237,7 +237,7 @@ void Resample( Sample* samp, u32 newsize )
 									(samp->loop_type ? 
 										((double)(src8[lpoint + (posi + 1 - oldlength)])) : 0) : 
 										((double)(src8[posi+1]));
-			s3 = (posi+1) >= oldlength ? 
+			s3 = (posi+2) >= oldlength ?
 									(samp->loop_type ? 
 										((double)(src8[lpoint + (posi + 2 - oldlength)])) : 0) : 
 										((double)(src8[posi+2]));


### PR DESCRIPTION
Thank you for your hard work on the project.

I detected this 1-byte invalid access while using `valgrind` to check for issues while preparing for a library build. I've never seen it cause any actual issues, but that's often the nature of undefined behavior. Thanks for your consideration!